### PR TITLE
Detect and evict dead connections

### DIFF
--- a/go/beacon.go
+++ b/go/beacon.go
@@ -73,9 +73,8 @@ func (b *Beacon) run() {
 	}
 }
 
-// sendPing pings the client and waits up to timeout for the pong. On failure the
-// peer is unresponsive, so close now (no handshake) to unblock the read loop and
-// surface the disconnect, and stop the beacon.
+// sendPing pings the client and waits up to timeout for the pong.
+// On failure the peer is unresponsive, so close now (no handshake).
 func (b *Beacon) sendPing() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
 	defer cancel()

--- a/go/beacon.go
+++ b/go/beacon.go
@@ -2,7 +2,7 @@ package netcode
 
 import (
 	"context"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -30,34 +30,24 @@ type Beacon struct {
 	timeout  time.Duration
 	ticker   *time.Ticker
 	done     chan bool
-	mu       sync.RWMutex
-	running  bool
+	running  atomic.Bool
 }
 
 func (b *Beacon) Start() {
-	b.mu.Lock()
-	if b.running {
-		b.mu.Unlock()
+	if !b.running.CompareAndSwap(false, true) {
 		return
 	}
-	b.running = true
-	b.mu.Unlock()
 
 	go b.run()
 	b.sendPing()
 }
 
 func (b *Beacon) Stop() {
-	b.mu.Lock()
-	if !b.running {
-		b.mu.Unlock()
+	if !b.running.CompareAndSwap(true, false) {
 		return
 	}
-	b.running = false
-	b.mu.Unlock()
 
-	// done is buffered (cap 1) so this never blocks, even while run() is parked
-	// inside a ping waiting for the timeout.
+	// done is buffered, so this never blocks even while run() is mid-ping.
 	b.done <- true
 }
 
@@ -67,13 +57,7 @@ func (b *Beacon) Destroy() {
 
 func (b *Beacon) run() {
 	defer b.ticker.Stop()
-	defer func() {
-		// Clear running on any exit (including the ping-failure path below) so a
-		// later Start can restart the beacon.
-		b.mu.Lock()
-		b.running = false
-		b.mu.Unlock()
-	}()
+	defer b.running.Store(false)
 
 	b.ticker.Reset(b.interval)
 
@@ -89,21 +73,16 @@ func (b *Beacon) run() {
 	}
 }
 
-// sendPing pings the client and waits up to timeout for the pong. A successful
-// pong reports the round-trip latency. A failure (timeout or dead connection)
-// closes the socket so the read loop unblocks and the disconnect is detected,
-// and returns false to stop the beacon. This is what evicts silently-dropped
-// connections (closed laptop, lost wifi) that never send a close frame.
+// sendPing pings the client and waits up to timeout for the pong. On failure the
+// peer is unresponsive, so close now (no handshake) to unblock the read loop and
+// surface the disconnect, and stop the beacon.
 func (b *Beacon) sendPing() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
 	defer cancel()
 
 	start := time.Now()
-	err := b.socket.PingContext(ctx)
 
-	if err != nil {
-		// The peer is unresponsive: close immediately rather than attempting a
-		// handshake it will never answer, so the read loop unblocks at once.
+	if err := b.socket.PingContext(ctx); err != nil {
 		b.socket.CloseNow()
 		return false
 	}

--- a/go/beacon.go
+++ b/go/beacon.go
@@ -1,6 +1,7 @@
 package netcode
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -10,8 +11,9 @@ func CreateBeacon(socket *Socket, interval time.Duration, callback func(time.Dur
 		socket:   socket,
 		callback: callback,
 		interval: interval,
+		timeout:  interval,
 		ticker:   time.NewTicker(interval),
-		done:     make(chan bool),
+		done:     make(chan bool, 1),
 	}
 
 	b.ticker.Stop()
@@ -25,33 +27,53 @@ type Beacon struct {
 	socket   *Socket
 	callback func(time.Duration)
 	interval time.Duration
+	timeout  time.Duration
 	ticker   *time.Ticker
 	done     chan bool
-	ping     time.Time
 	mu       sync.RWMutex
 	running  bool
 }
 
 func (b *Beacon) Start() {
-	if !b.running {
-		go b.run()
-		b.sendPing()
+	b.mu.Lock()
+	if b.running {
+		b.mu.Unlock()
+		return
 	}
+	b.running = true
+	b.mu.Unlock()
+
+	go b.run()
+	b.sendPing()
 }
 
 func (b *Beacon) Stop() {
-	if b.running {
-		b.done <- true
+	b.mu.Lock()
+	if !b.running {
+		b.mu.Unlock()
+		return
 	}
+	b.running = false
+	b.mu.Unlock()
+
+	// done is buffered (cap 1) so this never blocks, even while run() is parked
+	// inside a ping waiting for the timeout.
+	b.done <- true
 }
 
 func (b *Beacon) Destroy() {
 	b.Stop()
-	close(b.done)
 }
 
 func (b *Beacon) run() {
 	defer b.ticker.Stop()
+	defer func() {
+		// Clear running on any exit (including the ping-failure path below) so a
+		// later Start can restart the beacon.
+		b.mu.Lock()
+		b.running = false
+		b.mu.Unlock()
+	}()
 
 	b.ticker.Reset(b.interval)
 
@@ -60,17 +82,33 @@ func (b *Beacon) run() {
 		case <-b.done:
 			return
 		case <-b.ticker.C:
-			b.sendPing()
+			if !b.sendPing() {
+				return
+			}
 		}
 	}
 }
 
-func (b *Beacon) sendPing() {
-	ping := time.Now()
-	err := b.socket.Ping()
-	pong := time.Now()
+// sendPing pings the client and waits up to timeout for the pong. A successful
+// pong reports the round-trip latency. A failure (timeout or dead connection)
+// closes the socket so the read loop unblocks and the disconnect is detected,
+// and returns false to stop the beacon. This is what evicts silently-dropped
+// connections (closed laptop, lost wifi) that never send a close frame.
+func (b *Beacon) sendPing() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
 
-	if err == nil {
-		b.callback(pong.Sub(ping))
+	start := time.Now()
+	err := b.socket.PingContext(ctx)
+
+	if err != nil {
+		// The peer is unresponsive: close immediately rather than attempting a
+		// handshake it will never answer, so the read loop unblocks at once.
+		b.socket.CloseNow()
+		return false
 	}
+
+	b.callback(time.Since(start))
+
+	return true
 }

--- a/go/liveness_test.go
+++ b/go/liveness_test.go
@@ -117,18 +117,12 @@ func TestBeaconStartStop(t *testing.T) {
 	}
 	b.ticker.Stop()
 
-	b.mu.Lock()
-	b.running = true
-	b.mu.Unlock()
+	b.running.Store(true)
 	go b.run()
 
 	b.Stop()
 
-	b.mu.RLock()
-	running := b.running
-	b.mu.RUnlock()
-
-	if running {
+	if b.running.Load() {
 		t.Fatal("beacon still marked running after Stop")
 	}
 

--- a/go/liveness_test.go
+++ b/go/liveness_test.go
@@ -1,0 +1,137 @@
+package netcode
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func testEncoder() *BinaryEncoder {
+	return CreateBinaryEncoder([]*RegisteredCodec{}, UInt8Codec{})
+}
+
+func wsURL(s *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(s.URL, "http")
+}
+
+// TestReadTimeoutEvictsSilentSocket verifies that a connection which sends no
+// data within the read deadline is closed, firing Sockets.Out. The client keeps
+// reading (so it auto-answers protocol pings); only the data read-deadline can
+// trigger the closure here.
+func TestReadTimeoutEvictsSilentSocket(t *testing.T) {
+	sockets := CreateSockets(testEncoder(), 256, 1)
+	sockets.SetReadTimeout(150 * time.Millisecond)
+
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		if _, err := sockets.Add(c); err != nil {
+			t.Errorf("add: %v", err)
+			return
+		}
+		<-handlerDone
+	}))
+	defer server.Close()
+	defer close(handlerDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, _, err := websocket.Dial(ctx, wsURL(server), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.CloseNow()
+
+	// Keep reading so the client auto-responds to pings but never sends data.
+	go func() { client.Read(ctx) }()
+
+	select {
+	case <-sockets.Out:
+		// Evicted as expected.
+	case <-time.After(time.Second):
+		t.Fatal("silent socket was not evicted by the read deadline")
+	}
+}
+
+// TestBeaconEvictsUnresponsiveSocket verifies that the beacon closes a
+// connection that stops answering pings. The client never reads, so it never
+// auto-pongs; the bounded ping must time out and close the socket.
+func TestBeaconEvictsUnresponsiveSocket(t *testing.T) {
+	sockets := CreateSockets(testEncoder(), 256, 1)
+
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		socket, err := sockets.Add(c)
+		if err != nil {
+			t.Errorf("add: %v", err)
+			return
+		}
+		CreateBeacon(socket, 100*time.Millisecond, func(time.Duration) {})
+		<-handlerDone
+	}))
+	defer server.Close()
+	defer close(handlerDone)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client, _, err := websocket.Dial(ctx, wsURL(server), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.CloseNow()
+
+	// Never read: the client will not auto-answer pings, so the beacon's ping
+	// times out and the socket is force-closed.
+	select {
+	case <-sockets.Out:
+		// Evicted as expected.
+	case <-time.After(time.Second):
+		t.Fatal("unresponsive socket was not evicted by the beacon")
+	}
+}
+
+// TestBeaconStartStop verifies the running flag is honoured so Stop actually
+// halts the beacon and a subsequent Start can restart it without leaking.
+func TestBeaconStartStop(t *testing.T) {
+	b := &Beacon{
+		interval: time.Hour,
+		timeout:  time.Hour,
+		ticker:   time.NewTicker(time.Hour),
+		done:     make(chan bool, 1),
+	}
+	b.ticker.Stop()
+
+	b.mu.Lock()
+	b.running = true
+	b.mu.Unlock()
+	go b.run()
+
+	b.Stop()
+
+	b.mu.RLock()
+	running := b.running
+	b.mu.RUnlock()
+
+	if running {
+		t.Fatal("beacon still marked running after Stop")
+	}
+
+	// A second Stop must be a no-op (not block, not panic).
+	b.Stop()
+}

--- a/go/socket.go
+++ b/go/socket.go
@@ -3,23 +3,31 @@ package netcode
 import (
 	"context"
 	"github.com/coder/websocket"
+	"time"
 )
 
 func CreateSocket(id uint, c *websocket.Conn, encoder *BinaryEncoder, in chan SocketMessage) *Socket {
-	return &Socket{id, c, encoder, in}
+	return &Socket{ID: id, Conn: c, Encoder: encoder, In: in}
 }
 
 type Socket struct {
-	ID      uint
-	Conn    *websocket.Conn
-	Encoder *BinaryEncoder
-	In      chan SocketMessage
+	ID          uint
+	Conn        *websocket.Conn
+	Encoder     *BinaryEncoder
+	In          chan SocketMessage
+	readTimeout time.Duration
 }
 
 type SocketMessage struct {
 	Socket  *Socket
 	Message *Message
 	Err     error
+}
+
+// SetReadTimeout bounds how long Run waits for an incoming message before
+// treating the connection as dead. Zero (the default) disables the deadline.
+func (s *Socket) SetReadTimeout(d time.Duration) {
+	s.readTimeout = d
 }
 
 func (s *Socket) Send(message *Message) {
@@ -34,12 +42,27 @@ func (s *Socket) Write(data []byte) {
 	s.Conn.Write(context.Background(), websocket.MessageBinary, data)
 }
 
+// Ping sends a ping frame and waits for the pong, blocking until it arrives or
+// the connection fails. Prefer PingContext to bound the wait.
 func (s *Socket) Ping() error {
 	return s.Conn.Ping(context.Background())
 }
 
+// PingContext sends a ping frame and waits for the pong, returning early if ctx
+// is cancelled or its deadline elapses.
+func (s *Socket) PingContext(ctx context.Context) error {
+	return s.Conn.Ping(ctx)
+}
+
 func (s *Socket) Close(code int, reason string) error {
 	return s.Conn.Close(websocket.StatusCode(code), reason)
+}
+
+// CloseNow closes the connection immediately without a close handshake. Use it
+// for a peer already known to be unresponsive, where waiting for a handshake
+// reply would only stall.
+func (s *Socket) CloseNow() error {
+	return s.Conn.CloseNow()
 }
 
 func (s *Socket) Run(onClose func(*Socket)) {
@@ -49,7 +72,9 @@ func (s *Socket) Run(onClose func(*Socket)) {
 	}()
 
 	for {
-		_, data, err := s.Conn.Read(context.Background())
+		ctx, cancel := s.readContext()
+		_, data, err := s.Conn.Read(ctx)
+		cancel()
 
 		if err != nil {
 			return
@@ -57,6 +82,16 @@ func (s *Socket) Run(onClose func(*Socket)) {
 
 		s.Handle(data)
 	}
+}
+
+// readContext returns the context governing a single Read: bounded by
+// readTimeout when set, otherwise a plain cancellable background context.
+func (s *Socket) readContext() (context.Context, context.CancelFunc) {
+	if s.readTimeout <= 0 {
+		return context.WithCancel(context.Background())
+	}
+
+	return context.WithTimeout(context.Background(), s.readTimeout)
 }
 
 func (s *Socket) Handle(data []byte) {

--- a/go/socket.go
+++ b/go/socket.go
@@ -24,8 +24,8 @@ type SocketMessage struct {
 	Err     error
 }
 
-// SetReadTimeout bounds how long Run waits for an incoming message before
-// treating the connection as dead. Zero (the default) disables the deadline.
+// SetReadTimeout bounds how long Run waits for a message before closing the
+// connection. Zero (the default) disables the deadline.
 func (s *Socket) SetReadTimeout(d time.Duration) {
 	s.readTimeout = d
 }
@@ -42,14 +42,11 @@ func (s *Socket) Write(data []byte) {
 	s.Conn.Write(context.Background(), websocket.MessageBinary, data)
 }
 
-// Ping sends a ping frame and waits for the pong, blocking until it arrives or
-// the connection fails. Prefer PingContext to bound the wait.
 func (s *Socket) Ping() error {
 	return s.Conn.Ping(context.Background())
 }
 
-// PingContext sends a ping frame and waits for the pong, returning early if ctx
-// is cancelled or its deadline elapses.
+// PingContext waits for the pong, returning early if ctx is cancelled.
 func (s *Socket) PingContext(ctx context.Context) error {
 	return s.Conn.Ping(ctx)
 }
@@ -58,9 +55,7 @@ func (s *Socket) Close(code int, reason string) error {
 	return s.Conn.Close(websocket.StatusCode(code), reason)
 }
 
-// CloseNow closes the connection immediately without a close handshake. Use it
-// for a peer already known to be unresponsive, where waiting for a handshake
-// reply would only stall.
+// CloseNow closes immediately, without a close handshake.
 func (s *Socket) CloseNow() error {
 	return s.Conn.CloseNow()
 }
@@ -84,8 +79,6 @@ func (s *Socket) Run(onClose func(*Socket)) {
 	}
 }
 
-// readContext returns the context governing a single Read: bounded by
-// readTimeout when set, otherwise a plain cancellable background context.
 func (s *Socket) readContext() (context.Context, context.CancelFunc) {
 	if s.readTimeout <= 0 {
 		return context.WithCancel(context.Background())

--- a/go/sockets.go
+++ b/go/sockets.go
@@ -5,6 +5,7 @@ import (
 	"github.com/coder/websocket"
 	"log"
 	"sync"
+	"time"
 )
 
 func CreateSockets(encoder *BinaryEncoder, maxId uint, inBufferSize int) *Sockets {
@@ -18,12 +19,19 @@ func CreateSockets(encoder *BinaryEncoder, maxId uint, inBufferSize int) *Socket
 }
 
 type Sockets struct {
-	Encoder *BinaryEncoder
-	In      chan SocketMessage
-	Out     chan *Socket
-	List    map[uint]*Socket
-	maxId   uint
-	mu      sync.RWMutex
+	Encoder     *BinaryEncoder
+	In          chan SocketMessage
+	Out         chan *Socket
+	List        map[uint]*Socket
+	maxId       uint
+	readTimeout time.Duration
+	mu          sync.RWMutex
+}
+
+// SetReadTimeout sets the read deadline applied to every socket created from
+// here on. Zero (the default) disables the deadline.
+func (ss *Sockets) SetReadTimeout(d time.Duration) {
+	ss.readTimeout = d
 }
 
 func (ss *Sockets) generateId() (uint, error) {
@@ -48,6 +56,7 @@ func (ss *Sockets) Add(c *websocket.Conn) (*Socket, error) {
 	}
 
 	socket := CreateSocket(id, c, ss.Encoder, ss.In)
+	socket.SetReadTimeout(ss.readTimeout)
 
 	ss.mu.Lock()
 	ss.List[socket.ID] = socket

--- a/go/sockets.go
+++ b/go/sockets.go
@@ -28,8 +28,8 @@ type Sockets struct {
 	mu          sync.RWMutex
 }
 
-// SetReadTimeout sets the read deadline applied to every socket created from
-// here on. Zero (the default) disables the deadline.
+// SetReadTimeout sets the read deadline applied to sockets created after it.
+// Zero (the default) disables the deadline.
 func (ss *Sockets) SetReadTimeout(d time.Duration) {
 	ss.readTimeout = d
 }


### PR DESCRIPTION
## Problem

A silently-dropped connection — a closed laptop, lost wifi, a backgrounded mobile tab — never sends a WebSocket close frame, and nothing on the server detected it:

- `socket.Run` read with `context.Background()`, so the read loop blocked forever waiting for data that would never arrive.
- The ping beacon pinged with `context.Background()` (so a ping to a dead peer blocked forever) and **ignored** ping failures — it only ever reported latency, never closed anything.
- The beacon's `running` flag was never set to `true`, so `Stop()` was a no-op and every `Start()` leaked another goroutine.

Net effect: such a socket was never closed and `Sockets.Out` never fired, so consumers never observed the disconnect.

## Fix

- **beacon**: ping with a bounded context (derived from the interval) and `CloseNow()` the socket on failure, so the read loop unblocks immediately and the disconnect surfaces. Repair the lifecycle — set/reset the `running` flag, buffer the `done` channel so `Stop()` never blocks, and clear `running` on any `run()` exit so a beacon can be cleanly restarted.
- **socket**: add `PingContext`, `CloseNow`, and a configurable per-socket read deadline applied in `Run`. Zero disables it (the default — existing behaviour is unchanged).
- **sockets**: `SetReadTimeout` propagates the deadline to every socket created via `Add`.

All changes are additive — no exported signatures change.

## Tests

New integration tests cover the read-deadline eviction path, the beacon eviction path (unresponsive peer), and the `Start`/`Stop` running-flag behaviour. Full suite passes, `go vet` clean, race-detector clean.