### PR TITLE
feat(server): add broadcast/commodity methods to MapClientDirectory

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -74,6 +74,5 @@ server.on('pong', ({ client, duration }) => console.info('Client %s ping: %sms',
 server.on('ready', () => console.info('Listening on port %s', port));
 
 function broadcastTotal() {
-    const { length } = server.clients;
-    server.clients.forEach(client => client.send('total', length));
+    server.clients.sendAll('total', server.clients.count());
 }

--- a/src/server/Client.js
+++ b/src/server/Client.js
@@ -41,7 +41,16 @@ export default class Client extends EventEmitter {
      * @param {Object} data
      */
     send(name, data) {
-        this.socket.send(this.encoder.encode(name, data));
+        this.write(this.encoder.encode(name, data));
+    }
+
+    /**
+     * Write buffer data
+     *
+     * @param {ArrayBuffer} data
+     */
+    write(data) {
+        this.socket.send(data);
     }
 
     /**

--- a/src/server/MapClientDirectory.js
+++ b/src/server/MapClientDirectory.js
@@ -4,7 +4,8 @@
  * Re-use ids after client disconnection.
  */
 export default class MapClientDirectory {
-    constructor(max = Math.pow(2, 16)) {
+    constructor(encoder, max = Math.pow(2, 16)) {
+        this.encoder = encoder;
         this.max = max;
         this.clients = new Map();
     }
@@ -52,6 +53,10 @@ export default class MapClientDirectory {
         this.clients.delete(client.id);
     }
 
+    count() {
+        return this.length;
+    }
+
     /**
      * Execute the given callback for every client
      *
@@ -79,5 +84,60 @@ export default class MapClientDirectory {
      */
     forFilter(filter, callback) {
         this.clients.forEach(client => filter(client) && callback(client));
+    }
+
+    /**
+     * Write buffer to all clients
+     *
+     * @param  {ArrayBuffer} data
+     */
+    writeAll(data) {
+        this.clients.forEach(client => client.write(data));
+    }
+
+    /**
+     * Write buffer to all other clients
+     *
+     * @param  {Client} target Client to exclude
+     * @param  {ArrayBuffer} data
+     */
+    writeOther(target, data) {
+        this.clients.forEach(client => {
+            if (client.id !== target.id) {
+                client.write(data);
+            }
+        });
+    }
+
+    /**
+     * Encode and send a message to a single client
+     *
+     * @param {Client} client
+     * @param {String} name
+     * @param {Object} data
+     */
+    send(client, name, data) {
+        client.send(name, data);
+    }
+
+    /**
+     * Encode and send a message to all clients
+     *
+     * @param {String} name
+     * @param {Object} data
+     */
+    sendAll(name, data) {
+        this.writeAll(this.encoder.encode(name, data));
+    }
+
+    /**
+     * Encode and send a message to all other clients
+     *
+     * @param {Client} target Client to exclude
+     * @param {String} name
+     * @param {Object} data
+     */
+    sendOther(target, name, data) {
+        this.writeOther(target, this.encoder.encode(name, data));
     }
 }

--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -22,7 +22,7 @@ export default class Server extends EventEmitter {
         encoder = new JsonEncoder(),
         pingInterval = 30,
         maxPayload = Math.pow(2, 9),
-        clients = new MapClientDirectory(),
+        clients = null,
         autoStart = true
     ) {
         super();
@@ -43,7 +43,7 @@ export default class Server extends EventEmitter {
             server: this.server,
             maxPayload
         });
-        this.clients = clients;
+        this.clients = clients ?? new MapClientDirectory(encoder);
         this.pingInterval = pingInterval;
 
         this.server.on('request', this.onRequest);

--- a/test/directory.test.js
+++ b/test/directory.test.js
@@ -1,0 +1,124 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import MapClientDirectory from '../src/server/MapClientDirectory.js';
+
+/**
+ * Minimal encoder stub: encodes to a recognisable string buffer.
+ */
+const encoder = { encode: (name, data) => `[${name}:${data}]` };
+
+/**
+ * Minimal client stub recording what it received.
+ */
+function createClient() {
+    return {
+        id: null,
+        sent: [],
+        written: [],
+        send(name, data) { this.sent.push(`${name}:${data}`); },
+        write(buffer) { this.written.push(buffer); },
+    };
+}
+
+describe('MapClientDirectory', () => {
+    let directory;
+    let a;
+    let b;
+    let c;
+
+    beforeEach(() => {
+        directory = new MapClientDirectory(encoder);
+        a = createClient();
+        b = createClient();
+        c = createClient();
+        directory.add(a);
+        directory.add(b);
+        directory.add(c);
+    });
+
+    test('assigns incremental ids and reuses freed ones', () => {
+        expect([a.id, b.id, c.id]).toEqual([0, 1, 2]);
+
+        directory.remove(b);
+        const d = createClient();
+        directory.add(d);
+
+        expect(d.id).toBe(1);
+    });
+
+    test('count() and length report the number of clients', () => {
+        expect(directory.count()).toBe(3);
+        expect(directory.length).toBe(3);
+
+        directory.remove(a);
+
+        expect(directory.count()).toBe(2);
+        expect(directory.length).toBe(2);
+    });
+
+    test('forEach visits every client', () => {
+        const visited = [];
+        directory.forEach(client => visited.push(client.id));
+
+        expect(visited.sort()).toEqual([0, 1, 2]);
+    });
+
+    test('forOther visits every client except the target', () => {
+        const visited = [];
+        directory.forOther(b, client => visited.push(client.id));
+
+        expect(visited.sort()).toEqual([0, 2]);
+    });
+
+    test('forFilter visits only matching clients', () => {
+        const visited = [];
+        directory.forFilter(client => client.id > 0, client => visited.push(client.id));
+
+        expect(visited.sort()).toEqual([1, 2]);
+    });
+
+    test('writeAll writes the same buffer to every client', () => {
+        directory.writeAll('raw');
+
+        expect(a.written).toEqual(['raw']);
+        expect(b.written).toEqual(['raw']);
+        expect(c.written).toEqual(['raw']);
+    });
+
+    test('writeOther writes to every client except the target', () => {
+        directory.writeOther(b, 'raw');
+
+        expect(a.written).toEqual(['raw']);
+        expect(b.written).toEqual([]);
+        expect(c.written).toEqual(['raw']);
+    });
+
+    test('send delegates encoding to a single client', () => {
+        directory.send(a, 'ping', 1);
+
+        expect(a.sent).toEqual(['ping:1']);
+        expect(b.sent).toEqual([]);
+    });
+
+    test('sendAll encodes once and writes the buffer to every client', () => {
+        directory.sendAll('total', 3);
+
+        expect(a.written).toEqual(['[total:3]']);
+        expect(b.written).toEqual(['[total:3]']);
+        expect(c.written).toEqual(['[total:3]']);
+    });
+
+    test('sendOther encodes once and writes to every client except the target', () => {
+        directory.sendOther(b, 'hi', 7);
+
+        expect(a.written).toEqual(['[hi:7]']);
+        expect(b.written).toEqual([]);
+        expect(c.written).toEqual(['[hi:7]']);
+    });
+
+    test('generateId throws when the directory is full', () => {
+        const full = new MapClientDirectory(encoder, 1);
+        full.add(createClient());
+
+        expect(() => full.add(createClient())).toThrow(/Max clients reached/);
+    });
+});


### PR DESCRIPTION
Mirror the Go port's Sockets API on the Node MapClientDirectory so both ports expose the same convenience methods:

- write/writeAll/writeOther for raw pre-encoded buffers
- send/sendAll/sendOther that encode once then fan out
- count() alias, and Client.write() to send a buffer without re-encoding

sendAll/sendOther delegate to writeAll/writeOther (encode once) to match the Go structure. Update the Node demo to use sendAll + count, mirroring the Go demo, and add unit tests for the directory.